### PR TITLE
[Documentation] added README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,152 @@
 # selfkey-main-contracts
 
-{{description}}
+Smart contracts implementing core functionality of the SelfKey network.
 
 * `develop` — [![CircleCI]({{circleci-badge-develop-link}})]({{circleci-project-develop-link}})
 * `master` — [![CircleCI]({{circleci-badge-master-link}})]({{circleci-project-master-link}})
 
 ## Overview
 
-This template is created to be used with [create-project](https://github.com/mafintosh/create-project), upon creating a new project, this README should be overwritten according to the project's needs.
+To date, there are 2 smart contracts implemented as part of the SelfKey main project:
+
+* SelfKeyMain.sol
+* PaymentSplitter.sol
+
+### SelfKeyMain.sol
+
+`SelfKeyMain` is designed to provide on-chain support for general functionality specific to the SelfKey
+platform, such as affiliate and vendor registration. Also, it works as a central address directory that other
+contracts or applications can query.
+
+`SelfkeyMain` implements the `WhitelistedRole` pattern by OpenZeppelin. i.e. there are 2 permissioning levels:
+
+* `WhitelistedAdmin`: can manage whitelisted addresses and execute methods with `onlyWhitelistAdmin` modifier.
+* `Whitelisted`: can execute methods with `onlyWhitelisted` modifier.
+
+Directory operations such as adding or changing addresses can be performed by `onlyWhitelistAdmin`. Methods for
+managing vendors and affiliates can be executed by `onlyWhitelisted`.
+
+This contract interacts with [SelfKey DID Ledger](https://github.com/SelfKeyFoundation/selfkey-did-ledger).
+
+#### SelfKeyMain Method Interface
+
+The following functions are implemented by the SelfKeyMain contract:
+
+**As address directory:**
+
+* `setAddress(bytes32 key, address _address)` (onlyWhitelistAdmin)
+* `getAddress(bytes32 key)`
+
+**Access management (onlyWhitelisted):**
+
+* `registerAffiliate(bytes32 affiliateID)`
+* `registerVendor(bytes32 vendorID)`
+* `removeAffiliate(bytes32 affiliateID)`
+* `removeVendor(bytes32 vendorID)`
+* `addAffiliateLink(bytes32 user, bytes32 affiliate) public onlyWhitelisted`
+* `removeAffiliateLink(bytes32 user) public onlyWhitelisted`
+
+**DIDLedger middleware:**
+
+* `createDID(bytes32 affiliateID) returns (bytes32)`
+* `resolveDID(bytes32 did) returns (address)`
+
+**Note:** Although transactions can be made directly on the DID Ledger, creating DIDs through the `SelfKeyMain`
+serves the purpose of potential linking to an affiliate, and this functionality might be improved to create
+more complex identity setups (e.g. ERC725) before creating the DID on the ledger.
+
+**This contract is planned to be upgradable via ZeppelinOS, yet the current version (1.0.0) still doesn't implement upgradability.**
+
+### PaymentSplitter.sol
+
+`PaymentSplitter` is a contract that receives a payment from a sender DID to a recipient DID. It checks for
+possible affiliate relationships stored on the `SelfKeyMain` instance, and performs splitting of funds
+according to percentages specified by the caller. _Service providers have to check if the payment and
+affiliate splitting were done correctly_.
+
+####Payment pre-conditions:
+
+* Sender must `approve` the payments contract to spend the required amount of tokens.
+* Sender, recipient and potential affiliates must have a valid DID registered on the DID Ledger.
+* Recipient DID is registered as a _Vendor_ on the SelfKeyMain. (i.e. `vendorStatus(did) -> true`)
+* Affiliates are registered as such on the SelfKeyMain. (i.e. `affiliateStatus(did) -> true`) and have a relationship to the sender DID (i.e. `affiliateLinks(senderDID) -> true`)
+
+#### Payment method
+
+Payments are done by invoking the `makePayment` method with the following parameters:
+
+* `bytes32 senderDID`: DID of the sender. The contract checks that transaction sender has control over DID.
+* `bytes32 recipientDID`: DID of the recipient. The contract checks that DID is registered as a Vendor.
+* `uint256 amount`: amount of KEY tokens being sent.
+* `bytes32 purchaseInfo`: 32 byte string describing the product/service and any other relevant info.
+_NOTE: encoding scheme for purchase info hasn't been defined_
+* `uint256 affiliate1Split`: percentage for affiliate level 1.
+* `uint256 affiliate2Split`: percentage for affiliate level 2.
+
+**Note**: Affiliate splitting percentages are not to be defined by the user, but should be pulled from a particular service (e.g. Airtable) by the client, and the payment recipient must verify this setup to prevent users from tampering with these parameters.
+
+#### Example code
+
+The following examples are using web3 1.0.x using async/await:
+
+**Role registration**
+
+```javascript
+// whitelistedAdmin adds whitelisted address
+await main.methods.addWhitelisted(whitelisted1).send({ 'from': admin1 })
+console.log(await main.methods.isWhitelisted(whitelisted1).call()) // true
+
+// register a DID as a Vendor
+await main.methods.registerVendor(vendorDID).send({ 'from': whitelisted1 })
+await main.methods.vendorStatus(vendorDID).call())  // true
+```
+
+**DID creation**:
+
+```javascript
+// user address calls main contract to create DID
+let tx = await main.methods.createDID(zero).send({ 'from': user1 })
+let did = tx.events.CreatedSelfKeyDID.returnValues.id
+// verify newly created DID
+console.log(ledger.methods.getController(did).call() == user1) // true
+```
+
+In the previous example, a 32-byte string of `zero` is passed as the _affiliateDID_, but can be used to link
+the new DID to a valid (previously registered) affiliate:
+
+```javascript
+// create new DID for affiliate
+let tx = await main.methods.createDID(zero).send({ 'from': affiliate1 })
+let affiliate1DID = tx.events.CreatedSelfKeyDID.returnValues.id
+
+// previously whitelisted address registers affiliate
+await main.methods.registerAffiliate(affiliate1DID).send({ 'from': whitelisted1 })
+
+// user creates new DID with affiliate link
+tx = await main.methods.createDID(affiliate1DID).send({ 'from': user2 })
+let user2DID = tx.events.CreatedSelfKeyDID.returnValues.id
+console.log(await main.methods.affiliateLinks(user2DID).call() == affiliate1DID) // true
+```
+
+**Payment**
+
+```javascript
+// approve payment contract to get amount of tokens from user address
+await token.methods.approve(payments.address, 999999000000000000000000).send({ 'from': user1 })
+await payments.methods.makePayment(
+  tokenAddress,
+  user1DID,     // bytes32 senderDID
+  vendorDID,    // bytes32 recipientDID
+  10000,        // uint256 amount
+  info,         // bytes32 purchaseInfo
+  0,            // uint256 affiliate1Split
+  0,            // uint256 affiliate2Split
+).send({ 'from': user1 })
+```
 
 ## Development
 
-Smart contracts are being implemented using Solidity `0.5.4`.
+Smart contracts are implemented using Solidity version `0.5.4`.
 
 ### Prerequisites
 
@@ -24,11 +159,16 @@ Smart contracts are being implemented using Solidity `0.5.4`.
 
 ### Testing
 
+Truffle testing requires a `ganache-cli` instance running. Some tests require more than 10 accounts, therefore
+the number of accounts should be specified (e.g. run ganache with 12 generated accounts):
+
+    ganache-cli -a 12
+
 #### Standalone
 
     npm test
 
-or with code coverage
+or with code coverage (doesn't require ganache)
 
     npm run test:cov
 

--- a/contracts/PaymentSplitter.sol
+++ b/contracts/PaymentSplitter.sol
@@ -12,9 +12,7 @@ contract PaymentSplitter {
     using SafeERC20 for IERC20;
     using SafeMath for uint256;
 
-    //bytes32 constant LEDGER_KEY = keccak256(abi.encodePacked("DIDLedger"));
     SelfKeyMain public main;
-    IERC20 public token;  // SelfkeyToken contract
 
     event AffiliateCommissionPaid(
         address recipient,
@@ -28,15 +26,15 @@ contract PaymentSplitter {
         bytes32 purchaseInfo
     );
 
-    constructor(address _main, address _token) public {
+    constructor(address _main) public {
         main = SelfKeyMain(_main);
-        token = IERC20(_token);
     }
 
     /**
      *  Make a payment to a recipient address with escrow and two level affiliate splitting
      */
     function makePayment(
+        address _token,
         bytes32 senderDID,
         bytes32 recipientDID,
         uint256 amount,
@@ -47,6 +45,7 @@ contract PaymentSplitter {
         public
         returns (uint256)
     {
+        IERC20 token = IERC20(_token);  // SelfkeyToken contract
         require(main.vendorStatus(recipientDID), "Recipient DID is not registered as vendor");
 
         address recipientAddress = main.resolveDID(recipientDID);

--- a/migrations/2_deploy_ledger.js
+++ b/migrations/2_deploy_ledger.js
@@ -1,5 +1,4 @@
 const DIDLedger = artifacts.require("DIDLedger")
-//const SelfKeyMain = artifacts.require("SelfKeyMain");
 
 module.exports = function(deployer) {
   deployer.deploy(DIDLedger)

--- a/migrations/3_deploy_main.js
+++ b/migrations/3_deploy_main.js
@@ -1,5 +1,0 @@
-const SelfKeyMain = artifacts.require("SelfKeyMain")
-
-module.exports = function(deployer) {
-  deployer.deploy(SelfKeyMain)
-}

--- a/migrations/3_deploy_main_and_payments.js
+++ b/migrations/3_deploy_main_and_payments.js
@@ -1,0 +1,8 @@
+const SelfKeyMain = artifacts.require("SelfKeyMain")
+const PaymentSplitter = artifacts.require("PaymentSplitter")
+
+module.exports = function(deployer) {
+  deployer.deploy(SelfKeyMain).then(() => {
+    return deployer.deploy(PaymentSplitter, SelfKeyMain.address)
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -864,6 +864,12 @@
       "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
       "dev": true
     },
+    "dotenv": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.0.0.tgz",
+      "integrity": "sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg==",
+      "dev": true
+    },
     "drbg.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint:sol": "solhint contracts/**/*.sol"
   },
   "devDependencies": {
+    "dotenv": "^8.0.0",
     "solhint": "^1.5.1",
     "solidity-coverage": "^0.6.0-beta.3",
     "truffle-hdwallet-provider": "^1.0.9"

--- a/test/PaymentSplitter_tests.js
+++ b/test/PaymentSplitter_tests.js
@@ -38,7 +38,7 @@ contract("PaymentSplitter", accounts => {
 
     ledger = await DIDLedger.new()
     main = await SelfKeyMain.new()
-    payments = await PaymentSplitter.new(main.address, token.address)
+    payments = await PaymentSplitter.new(main.address)
 
     await main.setAddress(ledgerKey, ledger.address, { from: admin1 })
     await main.addWhitelisted(whitelisted1, { from: admin1 })
@@ -97,6 +97,7 @@ contract("PaymentSplitter", accounts => {
     it("cannot send from a DID not under control", async () => {
       await assertThrows(
         payments.makePayment(
+          token.address,
           user2DID,     // bytes32 senderDID
           vendorDID,    // bytes32 recipientDID
           10000,        // uint256 amount
@@ -111,6 +112,7 @@ contract("PaymentSplitter", accounts => {
     it("cannot make payment to an invalid vendor DID", async () => {
       await assertThrows(
         payments.makePayment(
+          token.address,
           user1DID,     // bytes32 senderDID
           user2DID,    // bytes32 recipientDID (not a registered vendor)
           10000,        // uint256 amount
@@ -125,6 +127,7 @@ contract("PaymentSplitter", accounts => {
     it("cannot make payment to an invalid vendor DID", async () => {
       await assertThrows(
         payments.makePayment(
+          token.address,
           user1DID,     // bytes32 senderDID
           user2DID,    // bytes32 recipientDID (not a registered vendor)
           10000,        // uint256 amount
@@ -141,6 +144,7 @@ contract("PaymentSplitter", accounts => {
       assert.equal(await ledger.getController(vendor2DID), 0)
       await assertThrows(
         payments.makePayment(
+          token.address,
           user1DID,     // bytes32 senderDID
           vendor2DID,    // bytes32 recipientDID (not a registered vendor)
           10000,        // uint256 amount
@@ -155,6 +159,7 @@ contract("PaymentSplitter", accounts => {
     it("user without affiliates makes a payment", async () => {
       // make two different payments
       await payments.makePayment(
+        token.address,
         user1DID,     // bytes32 senderDID
         vendorDID,    // bytes32 recipientDID
         10000,        // uint256 amount
@@ -173,6 +178,7 @@ contract("PaymentSplitter", accounts => {
       await token.approve(payments.address, 1000, { from: user3 })
 
       await payments.makePayment(
+        token.address,
         user3DID,     // bytes32 senderDID
         vendorDID,    // bytes32 recipientDID
         1000,         // uint256 amount
@@ -193,6 +199,7 @@ contract("PaymentSplitter", accounts => {
       await token.approve(payments.address, 10000, { from: user2 })
 
       await payments.makePayment(
+        token.address,
         user2DID,     // bytes32 senderDID
         vendorDID,    // bytes32 recipientDID
         10000,        // uint256 amount

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,18 +1,17 @@
+require('dotenv').config()
+
 const HDWalletProvider = require('truffle-hdwallet-provider')
 const fs = require('fs');
 
-const infuraKey = "a0fb364d78a54a6d84a6edf550b9a411"
+const infuraKey = process.env["INFURA_KEY"]
 const mainnetURL = "https://mainnet.infura.io/v3/" + infuraKey
 const ropstenURL = "https://ropsten.infura.io/v3/" + infuraKey
-//const providerUrlRopsten = "https://ropsten.infura.io/SYGRk61NUc3yN4NNRs60"
 
 const walletPath = "./local/wallet.json"
 const { mnemonic } = JSON.parse(fs.readFileSync(walletPath))
 
 const MainnetProvider = new HDWalletProvider(mnemonic, mainnetURL)
-const RopstenProvider = new HDWalletProvider(mnemonic, ropstenURL)
-
-//console.log("addresses = " + RopstenProvider.addresses)
+const RopstenProvider = new HDWalletProvider(mnemonic, ropstenURL, 0, 10)
 
 module.exports = {
   networks: {
@@ -55,6 +54,14 @@ module.exports = {
       // timeoutBlocks: 200,  // # of blocks before a deployment times out  (minimum/default: 50)
       skipDryRun: true     // Skip dry run before migrations? (default: false for public nets )
     },
+    mainnet: {
+      provider: () => MainnetProvider,
+      network_id: 1,
+      //from: addresses[0],
+      gas: 5500000,
+      gasPrice: 8000000000,
+      skipDryRun: true     // Skip dry run before migrations? (default: false for public nets )
+    }
 
     // Useful for private networks
     // private: {


### PR DESCRIPTION
Added documentation for the `SelfKeyMain` and `PaymentSplitter` contracts.

README file includes example code tested on ropsten deployments of the aforementioned contracts.